### PR TITLE
Fixed potential incomplete rendering

### DIFF
--- a/Class/GRCustomizableWindow.m
+++ b/Class/GRCustomizableWindow.m
@@ -332,6 +332,7 @@
     
     // force redraw
     [self setBounds:self.bounds];
+    [ self setNeedsDisplay: YES ];
 }
 
 - (void)_setTitlebarColor:(NSColor *)color
@@ -347,6 +348,7 @@
     
     // force redraw
     [self setBounds:self.bounds];
+    [ self setNeedsDisplay: YES ];
 }
 
 - (void)_setTitleStringColor:(NSColor *)color
@@ -358,6 +360,7 @@
     
     // force redraw
     [self setBounds:self.bounds];
+    [ self setNeedsDisplay: YES ];
 }
 
 - (void)_setTitleStringFont:(NSFont *)font
@@ -366,6 +369,7 @@
     
     // force redraw
     [self setBounds:self.bounds];
+    [ self setNeedsDisplay: YES ];
 }
 
 - (void)_setCenterControls:(BOOL)center
@@ -374,6 +378,7 @@
     
     // force redraw
     [self setBounds:self.bounds];
+    [ self setNeedsDisplay: YES ];
 }
 
 - (void)_setDrawGradients:(BOOL)draw
@@ -382,6 +387,7 @@
     
     // force redraw
     [self setBounds:self.bounds];
+    [ self setNeedsDisplay: YES ];
 }
 
 - (NSRect)titlebarRect


### PR DESCRIPTION
The problem is this statement: `[ self setBounds: self.bounds ];`

The `-setBounds:` method neither redisplays the receiver nor marks it as needing display, so we must do this ourselves with `setNeedsDisplay:`

Reproduce (gif):

![untitled](https://cloud.githubusercontent.com/assets/4256649/6885614/a4d29414-d65a-11e4-9ee9-8b515e4ef1bb.gif)
